### PR TITLE
Fix version file syntax error

### DIFF
--- a/CoatlAerospace/CoatlAerospaceRedux.Version
+++ b/CoatlAerospace/CoatlAerospaceRedux.Version
@@ -2,7 +2,7 @@
   "NAME": "Coatl AeroSpace Redux",
   "URL": "https://raw.githubusercontent.com/PadroneSF/Coatl-Aerospace-Redux/refs/heads/master/CoatlAerospace/CoatlAerospaceRedux.Version",
   "DOWNLOAD":"https://github.com/PadroneSF/Coatl-Aerospace-Redux/releases",
-  "CHANGE_LOG":"https://raw.githubusercontent.com/PadroneSF/Coatl-Aerospace-Redux/refs/heads/master/Changes.md"
+  "CHANGE_LOG":"https://raw.githubusercontent.com/PadroneSF/Coatl-Aerospace-Redux/refs/heads/master/Changes.md",
   "CHANGE_LOG_URL":"https://raw.githubusercontent.com/PadroneSF/Coatl-Aerospace-Redux/refs/heads/master/ChangeLog.md",
   "GITHUB":
     {


### PR DESCRIPTION
Hi @PadroneSF, the version file is missing a comma. This PR fixes that.

Noticed while reviewing KSP-CKAN/NetKAN#10556.

Cheers!
